### PR TITLE
Added windowing - Rms now stores an entire buffer of sample RMS, where the RMS is the RMS of the window of samples preceding that sample.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rms"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["mitchmindtree <mitchell.nordine@gmail.com>"]
 description = "A simple type for calculating and storing the RMS given some buffer of interleaved audio samples."
 readme = "README.md"
@@ -11,4 +11,3 @@ homepage = "https://github.com/RustAudio/rms"
 
 [dependencies]
 dsp-chain = "0.9.0"
-num = "0.1.27"

--- a/examples/test.rs
+++ b/examples/test.rs
@@ -10,9 +10,11 @@ fn main() {
 
     // The number of channels we want in our stream.
     const CHANNELS: u16 = 2;
+    // The size of the **Rms**' moving **Window**.
+    const WINDOW_SIZE: usize = 1028;
 
     // Construct our Rms reader.
-    let mut rms = Rms::new(CHANNELS as usize);
+    let mut rms = Rms::new(WINDOW_SIZE);
 
     // Callback used to construct the duplex sound stream.
     let callback = Box::new(move |input: &[f32], in_settings: Settings,
@@ -21,9 +23,13 @@ fn main() {
                                   _: CallbackFlags| {
 
         // Update our rms state.
-        rms.update(input, in_settings);
+        let n_channels = in_settings.channels as usize;
+        let n_frames = in_settings.frames as usize;
+        rms.update(input, n_channels, n_frames);
 
-        println!("Input RMS avg: {:?}, RMS per channel: {:?}", rms.avg(), rms.per_channel());
+        println!("Input RMS avg: {:?}, RMS per channel: {:?}",
+                 rms.avg(n_frames - 1),
+                 rms.per_channel(n_frames - 1));
 
         // Write the input to the output for fun.
         for (out_sample, in_sample) in output.iter_mut().zip(input.iter()) {
@@ -37,7 +43,7 @@ fn main() {
     let params = StreamParams::new().channels(CHANNELS as i32);
     let stream = SoundStream::new()
         .sample_hz(44_100.0)
-        .frames_per_buffer(512)
+        .frames_per_buffer(128)
         .duplex(params, params)
         .run_callback(callback)
         .unwrap();

--- a/examples/test.rs
+++ b/examples/test.rs
@@ -11,7 +11,7 @@ fn main() {
     // The number of channels we want in our stream.
     const CHANNELS: u16 = 2;
     // The size of the **Rms**' moving **Window**.
-    const WINDOW_SIZE: usize = 1028;
+    const WINDOW_SIZE: usize = 1024;
 
     // Construct our Rms reader.
     let mut rms = Rms::new(WINDOW_SIZE);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,56 +3,173 @@ extern crate dsp;
 extern crate num;
 
 use dsp::{Sample, Settings};
+use std::collections::VecDeque;
 
-pub type RmsUnit = dsp::Wave;
+/// The floating point **Wave** representing the continuous RMS.
+pub type Wave = dsp::Wave;
 
 /// A type for calculating RMS of a buffer of audio samples and storing it.
 #[derive(Clone, Debug)]
 pub struct Rms {
-    channels: Vec<RmsUnit>,
+    /// The number of samples used to calculate the RMS per sample.
+    n_window_samples: usize,
+    /// The RMS at each sample within the interleaved buffer.
+    ///
+    /// After an **Rms::update** this will represent the RMS at each sample for the previous
+    /// `n_window_samples` number of samples.
+    interleaved_rms: Vec<Wave>,
+    /// A **Channel** for each channel given by the Settings.
+    window_per_channel: Vec<Window>,
 }
+
+/// A wrapper around the ringbuffer of samples used to calculate the RMS per sample.
+#[derive(Clone, Debug)]
+pub struct Window {
+    /// The sample squares (i.e. `sample.powf(2.0)`) used to calculate the RMS per sample.
+    ///
+    /// When a new sample is received, the **Window** pops the front sample_square and adds the new
+    /// sample_square to the back.
+    sample_squares: VecDeque<Wave>,
+    /// The sum total of all sample_squares currently within the **Window**'s ring buffer.
+    sum: Wave,
+}
+
+
+impl Window {
+
+    /// Construct a new empty RMS **Window**.
+    pub fn new(n_window_samples: usize) -> Self {
+        Window {
+            sample_squares: (0..n_window_samples).map(|_| 0.0).collect(),
+            sum: 0.0,
+        }
+    }
+
+    /// Zeroes the sum and the buffer of sample_squares.
+    pub fn reset(&mut self) {
+        for sample_square in &mut self.sample_squares {
+            *sample_square = 0.0;
+        }
+        self.sum = 0.0;
+    }
+
+    /// The next RMS given the new sample in the sequence.
+    ///
+    /// The **Window** pops the front sample and adds the new sample to the back.
+    ///
+    /// The yielded RMS is the RMS of all sample_squares in the window after the new sample is added.
+    pub fn next_rms(&mut self, new_sample: Wave) -> Wave {
+        let removed_sample_square = self.sample_squares.pop_front().unwrap();
+        self.sum -= removed_sample_square;
+        let new_sample_square = new_sample.powf(2.0);
+        self.sample_squares.push_back(new_sample_square);
+        self.sum += new_sample_square;
+        let rms = self.sum / self.sample_squares.len() as Wave;
+        rms
+    }
+
+}
+
 
 impl Rms {
 
-    /// Construct an Rms reader for eading from buffers with a given number of interleaved
-    /// channels.
-    pub fn new(channels: usize) -> Rms {
-        Rms { channels: vec![0.0; channels] }
-    }
-
-    /// Update the stored RMS with the RMS of the given buffer of samples.
-    pub fn update<S>(&mut self, samples: &[S], settings: Settings) where S: Sample {
-        let channels = settings.channels as usize;
-        if self.channels.len() != channels {
-            // We need to reallocate our Vec with the correct number of channels.
-            self.channels = vec![0.0; channels];
-        }
-        // Determine the RMS for each channel, avoiding any allocations.
-        for i in 0..channels {
-            use num::Float;
-            let sum = samples.chunks(channels)
-                .map(|frame| frame[i])
-                .fold(0.0, |total, sample| total + sample.to_wave().powf(2.0));
-            let rms = (sum / settings.frames as RmsUnit).sqrt();
-            self.channels[i] = rms;
+    /// Construct a new **Rms** with the given window size as a number of samples.
+    pub fn new(n_window_samples: usize) -> Self {
+        Rms {
+            n_window_samples: n_window_samples,
+            interleaved_rms: Vec::new(),
+            window_per_channel: Vec::new(),
         }
     }
 
-    /// Return the average RMS across all channels.
-    pub fn avg(&self) -> RmsUnit {
-        self.channels.iter().fold(0.0, |total, &rms| total + rms) / self.channels.len() as f32
+    /// The same as **Rms::new** but also prepares the **Rms** for the given number of channels and
+    /// frames.
+    pub fn with_capacity(n_window_samples: usize, n_channels: usize, n_frames: usize) -> Self {
+        let window_per_channel = (0..n_channels).map(|_| Window::new(n_window_samples)).collect();
+        let n_samples = n_frames * n_channels;
+        let interleaved_rms = Vec::with_capacity(n_samples);
+        Rms {
+            n_window_samples: n_window_samples,
+            window_per_channel: window_per_channel,
+            interleaved_rms: interleaved_rms,
+        }
+    }
+
+    /// Resets the RMS **Window**s for each **Channel**.
+    pub fn reset_windows(&mut self) {
+        for window in &mut self.window_per_channel {
+            window.reset();
+        }
+    }
+
+    /// Update the stored RMS with the given interleaved buffer of samples.
+    pub fn update<S>(&mut self, samples: &[S], n_channels: usize, n_frames: usize)
+        where S: Sample,
+    {
+
+        // Resizes a **Vec** using the given function.
+        fn resize_vec<T, F>(vec: &mut Vec<T>, new_len: usize, mut new_elem: F)
+            where F: FnMut() -> T,
+        {
+            let len = vec.len();
+            if len > new_len {
+                vec.truncate(new_len);
+            } else if len < new_len {
+                let extension = (len..new_len).map(|_| new_elem());
+                vec.extend(extension);
+            }
+        }
+
+        // Ensure our `channels` match the `n_channels`.
+        if self.window_per_channel.len() != n_channels {
+            let n_window_samples = self.n_window_samples;
+            resize_vec(&mut self.window_per_channel, n_channels, || Window::new(n_window_samples));
+        }
+
+        // Ensure each channel's `rms_per_sample` buffer matches `n_frames`.
+        let n_samples = n_frames * n_channels;
+        if self.interleaved_rms.len() != n_samples {
+            resize_vec(&mut self.interleaved_rms, n_samples, || 0.0);
+        }
+
+        let mut idx = 0;
+        for _ in 0..n_frames {
+            for j in 0..n_channels {
+                let sample = samples[idx].to_wave();
+                let rms = self.window_per_channel[j].next_rms(sample);
+                self.interleaved_rms[idx] = rms;
+                idx += 1;
+            }
+        }
+    }
+
+    /// Return the average RMS across all channels at the given frame.
+    pub fn avg(&self, frame_idx: usize) -> Wave {
+        let frame_slice = self.per_channel(frame_idx);
+        let total_rms = frame_slice.iter().fold(0.0, |total, &rms| total + rms);
+        let avg_rms = total_rms / self.window_per_channel.len() as Wave;
+        avg_rms
     }
 
     /// Return the RMS for each channel.
-    pub fn per_channel(&self) -> &[RmsUnit] {
-        &self.channels
+    pub fn per_channel(&self, frame_idx: usize) -> &[Wave] {
+        let n_channels = self.window_per_channel.len();
+        let slice_idx = frame_idx * n_channels;
+        let end_idx = slice_idx + n_channels;
+        let frame_slice = &self.interleaved_rms[slice_idx..end_idx];
+        frame_slice
+    }
+
+    /// Borrow the internal RMS interleaved buffer.
+    pub fn interleaved_rms(&self) -> &[Wave] {
+        &self.interleaved_rms
     }
 
 }
 
 impl<S> dsp::Node<S> for Rms where S: Sample {
     fn audio_requested(&mut self, samples: &mut [S], settings: Settings) {
-        self.update(samples, settings);
+        self.update(samples, settings.channels as usize, settings.frames as usize);
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,5 @@
 
 extern crate dsp;
-extern crate num;
 
 use dsp::{Sample, Settings};
 use std::collections::VecDeque;


### PR DESCRIPTION
Incremented version to **0.3.0** for breaking change.
